### PR TITLE
Fixes #2

### DIFF
--- a/reading-list.md
+++ b/reading-list.md
@@ -1,21 +1,21 @@
 # Recommended CHERI Reading list from the point of the CapableVMs team
 
-Now first before you start reading first clone this repo: https://github.com/CTSRD-CHERI/cheribuild. 
-And run `./cheribuild.py run-riscv64-purecap -d -f`, you probably would have finished reading before 
+Now first before you start reading first clone this repo: https://github.com/CTSRD-CHERI/cheribuild.
+And run `./cheribuild.py run-riscv64-purecap -d -f`, you probably would have finished reading before
 it has finished building.
 
 This first most important thing that is needed would ideally be the CHERI ISA spec from Cambridge.
 Even when working on Morello it explains the motivation behind all the work: [link](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf).
-I would recommend starting with the Design Goals [p. 19] then reading through the chapter on 
-the CHERI Protection Model [p. 41] until the end of Architectural Capabilities [p. 59]. Most of the other stuff can be read later. 
+I would recommend starting with the Design Goals [p. 19] then reading through the chapter on
+the CHERI Protection Model [p. 41] until the end of Architectural Capabilities [p. 59]. Most of the other stuff can be read later.
 
 The next thing to go through is: [link](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-947.pdf).
 It's main purpose is to explain how CHERI capabilities can be used in C/C++, but all the examples
 are very basic. This document describes the functions defined in the llvm header files ([link](https://github.com/CTSRD-CHERI/llvm-project/blob/master/clang/lib/Headers/cheriintrin.h)) but it is also recommended to check the ones described in the cheribsd repo ([link](https://github.com/CTSRD-CHERI/llvm-project/blob/master/clang/lib/Headers/cheriintrin.h)).
 
 The last thing would be then to go back to the ISA specification for the arch you will target
-([Morello](https://documentation-service.arm.com/static/5f8da6fef86e16515cdb861e) [Cheri](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf))
-and see which instruction are not represented by the intrinsics in the header files. 
+([Morello](https://developer.arm.com/documentation/ddi0606/ak/?lang=en) [Cheri](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf))
+and see which instruction are not represented by the intrinsics in the header files.
 
 If you are interested about the different trains of thought throughout the 10 year life of the project
 I would recommend reading this in that order:


### PR DESCRIPTION
Fixed broken link in reading-list.md to ARM documentation on Morello ISA (on line beginning "The last thing would be then to go back to the ISA specification for the arch you will target [...]"